### PR TITLE
fix: handle null kms per week on vehicles

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from savings.emissions.calculate_emissions import calculate_emissions
 from savings.opex.calculate_opex import calculate_opex
 from savings.upfront_cost.calculate_upfront_cost import calculate_upfront_cost
 from models.recommend_next_action import recommend_next_action
+from utils.clean_household import clean_household
 
 app = FastAPI()
 
@@ -39,6 +40,7 @@ def health_check():
 @app.post("/savings")
 def calculate_household_savings(current_household: Household) -> Savings:
 
+    current_household = clean_household(current_household)
     electrified_household = electrify_household(current_household)
 
     emissions = calculate_emissions(current_household, electrified_household)

--- a/src/tests/utils/test_clean_household.py
+++ b/src/tests/utils/test_clean_household.py
@@ -1,0 +1,68 @@
+from openapi_client.models.household import Household
+from openapi_client.models.vehicle import Vehicle
+from openapi_client.models.vehicle_fuel_type_enum import VehicleFuelTypeEnum
+from utils.clean_household import clean_household, clean_vehicle
+from tests.mocks import mock_vehicle_petrol
+
+from unittest import TestCase
+from unittest.mock import patch, call
+
+
+class TestCleanHousehold(TestCase):
+
+    @patch("utils.clean_household.clean_vehicle")
+    def test_clean_household_no_vehicles(self, mock_clean_vehicle):
+        cleaned_household = clean_household(Household(vehicles=[]))
+        self.assertEqual(cleaned_household.vehicles, [])
+        mock_clean_vehicle.assert_not_called()
+
+    @patch("utils.clean_household.clean_vehicle")
+    def test_clean_household_single_vehicle(self, mock_clean_vehicle):
+        vehicle = Vehicle(fuel_type=VehicleFuelTypeEnum.PETROL, kms_per_week=None)
+        cleaned_vehicle = Vehicle(
+            fuel_type=VehicleFuelTypeEnum.PETROL, kms_per_week=123
+        )
+        mock_clean_vehicle.return_value = cleaned_vehicle
+
+        cleaned_household = clean_household(Household(vehicles=[vehicle]))
+
+        mock_clean_vehicle.assert_called_once_with(vehicle)
+        self.assertEqual(len(cleaned_household.vehicles), 1)
+        self.assertEqual(cleaned_household.vehicles[0].kms_per_week, 123)
+
+    @patch("utils.clean_household.clean_vehicle")
+    def test_clean_household_multiple_vehicles(self, mock_clean_vehicle):
+        vehicle1 = Vehicle(fuel_type=VehicleFuelTypeEnum.PETROL, kms_per_week=None)
+        vehicle2 = Vehicle(fuel_type=VehicleFuelTypeEnum.PETROL, kms_per_week=500)
+        cleaned_vehicle1 = Vehicle(
+            fuel_type=VehicleFuelTypeEnum.PETROL, kms_per_week=123
+        )
+        cleaned_vehicle2 = Vehicle(
+            fuel_type=VehicleFuelTypeEnum.PETROL, kms_per_week=500
+        )
+        mock_clean_vehicle.side_effect = [cleaned_vehicle1, cleaned_vehicle2]
+
+        cleaned_household = clean_household(Household(vehicles=[vehicle1, vehicle2]))
+
+        self.assertEqual(len(cleaned_household.vehicles), 2)
+        self.assertEqual(cleaned_household.vehicles[0].kms_per_week, 123)
+        self.assertEqual(cleaned_household.vehicles[1].kms_per_week, 500)
+        mock_clean_vehicle.assert_has_calls([call(vehicle1), call(vehicle2)])
+
+
+class TestCleanVehicle(TestCase):
+    def test_it_replaces_null_kms_with_avg(self):
+        assert clean_vehicle(
+            Vehicle(
+                fuelType=VehicleFuelTypeEnum.PETROL,
+                kms_per_week=None,
+                switchToEV=False,
+            )
+        ) == Vehicle(
+            fuelType=VehicleFuelTypeEnum.PETROL,
+            kms_per_week=round(11000 / 52),
+            switchToEV=False,
+        )
+
+    def test_it_does_not_change_if_kms_present(self):
+        assert clean_vehicle(mock_vehicle_petrol) == mock_vehicle_petrol

--- a/src/utils/clean_household.py
+++ b/src/utils/clean_household.py
@@ -1,0 +1,22 @@
+from constants.machines.vehicles import VEHICLE_AVG_DISTANCE_PER_YEAR_PER_CAPITA
+from openapi_client.models.household import Household
+from openapi_client.models.vehicle import Vehicle
+
+
+def clean_household(household: Household) -> Household:
+    household.vehicles = [clean_vehicle(v) for v in household.vehicles]
+    return household
+
+
+def clean_vehicle(vehicle: Vehicle) -> Vehicle:
+    return vehicle.copy(
+        update={
+            "kms_per_week": (
+                # average per capita is  212 km/week
+                # TODO: use average per vehicle, not capita
+                round(VEHICLE_AVG_DISTANCE_PER_YEAR_PER_CAPITA / 52)
+                if vehicle.kms_per_week is None
+                else vehicle.kms_per_week
+            )
+        }
+    )


### PR DESCRIPTION
The `Vehicle` model has an optional field `kms_per_week`, but the API currently crashes if it is null. This change handles the value by replacing it with the national average kms driven per week per capita.

I've done this in a way where it sets up a data cleaning stage. This can also be used in future iterations for handling inputs like `Don't know`.

This should be improved in future by using the average kms driven per car, not per capita. Since people often drive more than one car (average number of cars is 1.8 per household), the average kms per car is likely to be slightly lower.