### PR TITLE
feat: scale solar to period

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -37,6 +37,36 @@ These figures are taken from the Ministry for the Environment's [Measuring emiss
 ## Solar
 
 - Assumes 0.5% degradation per year, which averages out to 6.92% degradation over 30 years, or 93.08% performance of nameplate capacity over 30 years.
+- Assumes a static capacity factor per region, although this is likely to change over the next 30 years:
+
+| Region                 | Solar capacity factor (%) |
+|------------------------|---------------------------|
+| Northland             | 15.5%                     |
+| Auckland North        | 15.5%                     |
+| Auckland Central      | 15.5%                     |
+| Auckland East         | 15.5%                     |
+| Auckland West         | 15.5%                     |
+| Auckland South        | 15.5%                     |
+| Waikato               | 15.5%                     |
+| Bay of Plenty         | 15.5%                     |
+| Gisborne              | 15.0%                     |
+| Hawkes Bay            | 15.0%                     |
+| Taranaki              | 15.0%                     |
+| Manawatu Wanganui     | 15.0%                     |
+| Wellington            | 14.9%                     |
+| Tasman                | 15.0%                     |
+| Nelson                | 15.5%                     |
+| Marlborough           | 15.0%                     |
+| West Coast            | 15.0%                     |
+| Canterbury            | 14.3%                     |
+| Otago                 | 12.5%                     |
+| Southland             | 12.5%                     |
+| Stewart Island        | 12.5%                     |
+| Chatham Islands       | 12.5%                     |
+| Great Barrier Island  | 15.0%                     |
+| Overseas              | 15.0%                     |
+| Other                 | 15.0%                     |
+
 
 ## Battery
 

--- a/src/constants/solar.py
+++ b/src/constants/solar.py
@@ -9,6 +9,8 @@ SOLAR_SELF_CONSUMPTION_VEHICLES = 0.5
 SOLAR_FEEDIN_TARIFF_2024 = 0.135
 SOLAR_FEEDIN_TARIFF_AVG_15_YEARS = 0.15222  # real pricing
 
+SOLAR_OPERATIONAL_LIFETIME_YRS = 30
+
 # % of max capacity that it generates on average over 30 years, taking into account degradation
 SOLAR_AVG_DEGRADED_PERFORMANCE_30_YRS = 0.9308
 

--- a/src/utils/scale_daily_to_period.py
+++ b/src/utils/scale_daily_to_period.py
@@ -2,12 +2,17 @@ from constants.utils import DAYS_PER_YEAR, PeriodEnum
 from params import OPERATIONAL_LIFETIME
 
 
-def scale_daily_to_period(daily_val: float, period: PeriodEnum) -> float:
+def scale_daily_to_period(
+    daily_val: float,
+    period: PeriodEnum,
+    operational_lifetime: float = OPERATIONAL_LIFETIME,
+) -> float:
     """Scales a per-day value to the given period
 
     Args:
         daily_val (float): the value over one day, e.g. emissions per day, opex per day
         period (PeriodEnum): the period of time over which we want to scale the value
+        operational_lifetime (float): number of years that defines the operational lifetime
 
     Returns:
         float: the scaled value, e.g. emissions per week, opex per year
@@ -20,4 +25,4 @@ def scale_daily_to_period(daily_val: float, period: PeriodEnum) -> float:
     if period == PeriodEnum.YEARLY:
         return daily_val * DAYS_PER_YEAR
     if period == PeriodEnum.OPERATIONAL_LIFETIME:
-        return daily_val * DAYS_PER_YEAR * OPERATIONAL_LIFETIME
+        return daily_val * DAYS_PER_YEAR * operational_lifetime


### PR DESCRIPTION
Also allows `scale_daily_to_period` to take an `operational_lifetime` arg, since solar panels have a longer lifetime of 30 years compared to the 15 years we assume for the other appliances.
Should really mock the call to `scale_daily_to_period()` out but just shortcutting atm.