### PR TITLE
fix: sum energy for fuel type without self-consumption factor

### DIFF
--- a/src/constants/machines/machine_info.py
+++ b/src/constants/machines/machine_info.py
@@ -14,3 +14,9 @@ class MachineInfo(TypedDict):
 
 
 MachineInfoMap = Dict[MachineEnum, Union[MachineInfo, List[MachineInfo]]]
+
+MACHINE_CATEGORIES = [
+    "appliances",
+    "vehicles",
+    "other_appliances",
+]

--- a/src/constants/solar.py
+++ b/src/constants/solar.py
@@ -1,15 +1,10 @@
 from openapi_client.models.location_enum import LocationEnum
 
-
 # % of solar that is self-consumed
-SOLAR_SELF_CONSUMPTION_APPLIANCES = 0.5
-SOLAR_SELF_CONSUMPTION_VEHICLES = 0.5
-SOLAR_SELF_CONSUMPTION_OTHER_APPLIANCES = 0.5
-
 MACHINE_CATEGORY_TO_SELF_CONSUMPTION_RATE = {
-    "appliances": SOLAR_SELF_CONSUMPTION_APPLIANCES,
-    "vehicles": SOLAR_SELF_CONSUMPTION_VEHICLES,
-    "other_appliances": SOLAR_SELF_CONSUMPTION_OTHER_APPLIANCES,
+    "appliances": 0.5,
+    "vehicles": 0.5,
+    "other_appliances": 0.5,
 }
 
 # $/kWh

--- a/src/savings/opex/calculate_opex.py
+++ b/src/savings/opex/calculate_opex.py
@@ -41,25 +41,25 @@ def calculate_opex(
 
     # Weekly
     print(f"\n\n\nWEEKLY")
-    print(f"\nBefore\n")
+    print(f"\nBefore")
     weekly_before = _get_total_opex(current_household, PeriodEnum.WEEKLY)
-    print(f"\nAfter\n")
+    print(f"After")
     weekly_after = _get_total_opex(electrified_household, PeriodEnum.WEEKLY)
 
     print(f"\n\n\nYEARLY")
     # Yearly
-    print(f"\nBefore\n")
+    print(f"\nBefore")
     yearly_before = _get_total_opex(current_household, PeriodEnum.YEARLY)
-    print(f"\nAfter\n")
+    print(f"After")
     yearly_after = _get_total_opex(electrified_household, PeriodEnum.YEARLY)
 
     print(f"\n\n\nLIFETIME")
     # Operational lifetime
-    print(f"\nBefore\n")
+    print(f"\nBefore")
     lifetime_before = _get_total_opex(
         current_household, PeriodEnum.OPERATIONAL_LIFETIME
     )
-    print(f"\nAfter\n")
+    print(f"After")
     lifetime_after = _get_total_opex(
         electrified_household, PeriodEnum.OPERATIONAL_LIFETIME
     )

--- a/src/tests/savings/energy/test_get_machine_energy.py
+++ b/src/tests/savings/energy/test_get_machine_energy.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 
 from constants.machines.vehicles import VEHICLE_INFO
-from models.electrify_household import electrify_cooktop
 from openapi_client.models import (
     SpaceHeatingEnum,
     CooktopEnum,


### PR DESCRIPTION
There was a bug that was multiplying energy consumption by the self-consumption factor twice, resulting in half the intended electricity consumption.